### PR TITLE
Fix fatal error

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -90,13 +90,13 @@ final class Console
      */
     private function getNumberOfColumnsInteractive(): int
     {
-        if (\function_exists('shell_exec') && \preg_match('#\d+ (\d+)#', \shell_exec('stty size'), $match) === 1) {
+        if (\function_exists('shell_exec') && \preg_match('#\d+ (\d+)#', \shell_exec('stty size') ?? '', $match) === 1) {
             if ((int) $match[1] > 0) {
                 return (int) $match[1];
             }
         }
 
-        if (\function_exists('shell_exec') && \preg_match('#columns = (\d+);#', \shell_exec('stty'), $match) === 1) {
+        if (\function_exists('shell_exec') && \preg_match('#columns = (\d+);#', \shell_exec('stty') ?? '', $match) === 1) {
             if ((int) $match[1] > 0) {
                 return (int) $match[1];
             }


### PR DESCRIPTION
```
Fatal error: Uncaught TypeError: preg_match() expects parameter 2 to be string, null given in /.../vendor/sebastian/environment/src/Console.php:93
```