### PR TITLE
Don't ignore result of HHVM block

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -66,7 +66,7 @@ final class Runtime
             // @codeCoverageIgnoreEnd
         }
 
-        if (PHP_BINARY !== '') {
+        if (self::$binary === null && PHP_BINARY !== '') {
             self::$binary = \escapeshellarg(PHP_BINARY);
         }
 


### PR DESCRIPTION
HHVM defines PHP_BINARY, so the block just after is always taken, and the computed result (including `--php`) is ignored