### PR TITLE
Force PHP7 mode in HHVM

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -62,7 +62,8 @@ final class Runtime
                 self::$binary = PHP_BINARY;
             }
 
-            self::$binary = \escapeshellarg(self::$binary) . ' --php';
+            self::$binary = \escapeshellarg(self::$binary) . ' --php' .
+                ' -d hhvm.php7.all=1';
             // @codeCoverageIgnoreEnd
         }
 


### PR DESCRIPTION
This library only supports PHP7, so the current process is always in PHP7 mode, so the subprocess should be too.