### PR TITLE
Console - always pass resource to detect is it interactive or not

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -63,7 +63,7 @@ final class Console
             return $this->getNumberOfColumnsWindows();
         }
 
-        if (!$this->isInteractive(self::STDIN)) {
+        if (!$this->isInteractive(STDIN)) {
             return 80;
         }
 
@@ -75,7 +75,7 @@ final class Console
      *
      * @param int|resource $fileDescriptor
      */
-    public function isInteractive($fileDescriptor = self::STDOUT): bool
+    public function isInteractive($fileDescriptor = STDOUT): bool
     {
         return \function_exists('posix_isatty') && @\posix_isatty($fileDescriptor);
     }


### PR DESCRIPTION
as we can see in https://github.com/sebastianbergmann/environment/pull/25 , passing a resource instead of file description ID of it give use more possibility to detect is it interactive or not.

for next BC release, I would suggest to drop `int` from possible input types