### PR TITLE
Console - drop STDIN/STDOUT/STDERR constants

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -12,21 +12,6 @@ namespace SebastianBergmann\Environment;
 final class Console
 {
     /**
-     * @var int
-     */
-    public const STDIN  = 0;
-
-    /**
-     * @var int
-     */
-    public const STDOUT = 1;
-
-    /**
-     * @var int
-     */
-    public const STDERR = 2;
-
-    /**
      * Returns true if STDOUT supports colorization.
      *
      * This code has been copied and adapted from


### PR DESCRIPTION
cannot see them used in `phpunit` or `sebastian/*` packages