### PR TITLE
Enhancement: Run builds with different code coverage drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ php:
   - 7.3
   - 7.4snapshot
 
+env:
+  matrix:
+    - DRIVER="phpdbg"
+    - DRIVER="xdebug"
+
 before_install:
   - composer clear-cache
 
@@ -18,7 +23,8 @@ install:
   - travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.xml
+  - if [[ "$DRIVER" = 'phpdbg' ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  - if [[ "$DRIVER" != 'phpdbg' ]]; then vendor/bin/phpunit --coverage-clover=coverage.xml; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR

* [x] runs builds with different code coverage drivers

❗️ Blocks #43.

💁‍♂️ For reference, see https://github.com/sebastianbergmann/php-code-coverage/blob/d8ff5ed364cb7a1a32e6040076017b38f6cbdf07/.travis.yml.