### PR TITLE
use ternary operator shorthand instead of null coalescing operator

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -104,13 +104,13 @@ final class Console
      */
     private function getNumberOfColumnsInteractive(): int
     {
-        if (\function_exists('shell_exec') && \preg_match('#\d+ (\d+)#', \shell_exec('stty size') ?? '', $match) === 1) {
+        if (\function_exists('shell_exec') && \preg_match('#\d+ (\d+)#', \shell_exec('stty size') ?: '', $match) === 1) {
             if ((int) $match[1] > 0) {
                 return (int) $match[1];
             }
         }
 
-        if (\function_exists('shell_exec') && \preg_match('#columns = (\d+);#', \shell_exec('stty') ?? '', $match) === 1) {
+        if (\function_exists('shell_exec') && \preg_match('#columns = (\d+);#', \shell_exec('stty') ?: '', $match) === 1) {
             if ((int) $match[1] > 0) {
                 return (int) $match[1];
             }


### PR DESCRIPTION
Hi, I was trying to upgrade to PHPunit 7 and could not run tests 

```
./vendor/bin/phpunit --configuration ./tests/conf/phpunit.xml --testsuite all_suite

    Location: ./vendor/sebastian/environment/src/Console.php:107
    Message: Uncaught TypeError: preg_match() expects parameter 2 to be string, boolean given in ./vendor/sebastian/environment/src/Console.php:107

Stack trace:
#0 ./vendor/sebastian/environment/src/Console.php(107): preg_match('#\\d+ (\\d+)#', false, NULL)
#1 ./vendor/sebastian/environment/src/Console.php(80): SebastianBergmann\Environment\Console->getNumberOfColumnsInteractive()
#2 ./vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php(163): SebastianBergmann\Environment\Console->getNumberOfColumns()
#3 ./vendor/phpunit/phpunit/src/TextUI/TestRunner.php(313): PHPUnit\TextUI\ResultPrinter->__construct(NULL, false, 'never', false, 80, false)
```

i tried to manually add in that position to debug it
```
var_dump(\shell_exec('stty size'));
```
and seems shell_exec is returning false in this position but  not when I try to run it in indepdandant php file, not sure why, so trying to submit a patch for this

Enviroment 
```
disable_functions => no value => no value
PHP Version => 7.2.9
```