### PR TITLE
Add check for Darwin OS

### DIFF
--- a/tests/OperatingSystemTest.php
+++ b/tests/OperatingSystemTest.php
@@ -35,6 +35,14 @@ final class OperatingSystemTest extends TestCase
     }
 
     /**
+     * @requires OS Darwin
+     */
+    public function testFamilyReturnsDarwinWhenRunningOnDarwin(): void
+    {
+        $this->assertEquals('Darwin', $this->os->getFamily());
+    }
+
+    /**
      * @requires OS Windows
      */
     public function testGetFamilyReturnsWindowsWhenRunningOnWindows(): void


### PR DESCRIPTION
There are unit tests for checking if the environment is windows and linux. We should check for Macs (Darwin), too.