### PR TITLE
PHPUnit result cached not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.lock
 /composer.phar
 /.php_cs.cache
+.phpunit.result.cache


### PR DESCRIPTION
The result cache of phpunit should not be versioned.