### PR TITLE
Windows improvements to console capabilities

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -40,7 +40,7 @@ final class Console
 
         if ($this->isWindows()) {
             // @codeCoverageIgnoreStart
-            return (\defined('STDOUT') && \function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support(\STDOUT))
+            return (\defined('STDOUT') && \function_exists('sapi_windows_vt100_support') && @\sapi_windows_vt100_support(\STDOUT))
                 || false !== \getenv('ANSICON')
                 || 'ON' === \getenv('ConEmuANSI')
                 || 'xterm' === \getenv('TERM');
@@ -53,13 +53,7 @@ final class Console
             // @codeCoverageIgnoreEnd
         }
 
-        if ($this->isInteractive(\STDOUT)) {
-            return true;
-        }
-
-        $stat = @\fstat(\STDOUT);
-        // Check if formatted mode is S_IFCHR
-        return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+        return $this->isInteractive(\STDOUT);
     }
 
     /**
@@ -69,12 +63,12 @@ final class Console
      */
     public function getNumberOfColumns(): int
     {
-        if ($this->isWindows()) {
-            return $this->getNumberOfColumnsWindows();
-        }
-
         if (!$this->isInteractive(\defined('STDIN') ? \STDIN : self::STDIN)) {
             return 80;
+        }
+
+        if ($this->isWindows()) {
+            return $this->getNumberOfColumnsWindows();
         }
 
         return $this->getNumberOfColumnsInteractive();
@@ -90,8 +84,18 @@ final class Console
      */
     public function isInteractive($fileDescriptor = self::STDOUT): bool
     {
-        return (\is_resource($fileDescriptor) && \function_exists('stream_isatty') && @\stream_isatty($fileDescriptor)) // stream_isatty requires that descriptor is a real resource, not numeric ID of it
-            || (\function_exists('posix_isatty') && @\posix_isatty($fileDescriptor));
+        if (\is_resource($fileDescriptor)) {
+            // These functions require a descriptor that is a real resource, not a numeric ID of it
+            if (\function_exists('stream_isatty') && @\stream_isatty($fileDescriptor)) {
+                return true;
+            }
+
+            $stat = @\fstat(\STDOUT);
+            // Check if formatted mode is S_IFCHR
+            return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+        }
+
+        return \function_exists('posix_isatty') && @\posix_isatty($fileDescriptor);
     }
 
     private function isWindows(): bool


### PR DESCRIPTION
This reorganizes things so that Windows users can take advantage of new functions introduced in php7.2

It will also fix a failing test on Windows here: https://github.com/sebastianbergmann/phpunit/pull/3941

FYI: I was responsible for the color support stuff in Symfony\Console\Output\StreamOutput and Composer\XdebugHandler (https://github.com/composer/xdebug-handler/blob/cbe23383749496fe0f373345208b79568e4bc248/src/Process.php#L121)
 