### PR TITLE
Fix exception when DBG extension is loaded

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -127,6 +127,15 @@ final class Runtime
                 \phpversion('pcov')
             );
         }
+
+        // Catch-all default
+        // @codeCoverageIgnoreStart
+        return \sprintf(
+            '%s with [WARNING] injected%s coverage driver',
+            $this->getNameWithVersion(),
+            \extension_loaded('dbg') ? ' DBG' : ''
+        );
+        // @codeCoverageIgnoreEnd
     }
 
     public function getName(): string


### PR DESCRIPTION
The DBG extension injects its own code coverage driver for use with the
PhpEd IDE. http://www.nusphere.com/products/php_debugger.htm This causes
`Runtime::getNameWithVersionAndCodeCoverageDriver` to throw an exception
because it returns null, rather than a string.

I appreciate that this is entirely the fault of DBG but it has been hooking into PHPUnit for a very long time and the debugger itself has been around for years: http://www.php-debugger.com/dbg/

I have reported this issue to Nusphere so guess they will fix it. However this PR makes the code here less "brittle".

