### PR TITLE
Method to detect if xdebug is enabled by default

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -27,7 +27,9 @@ use function parse_ini_file;
 use function php_ini_loaded_file;
 use function php_ini_scanned_files;
 use function phpversion;
+use function shell_exec;
 use function sprintf;
+use function stripos;
 use function strpos;
 
 /**
@@ -39,6 +41,11 @@ final class Runtime
      * @var string
      */
     private static $binary;
+
+    /**
+     * @var bool
+     */
+    private static $xdebugLoadedByDefault;
 
     /**
      * Returns true when Xdebug or PCOV is available or
@@ -300,6 +307,18 @@ final class Runtime
         }
 
         return $diff;
+    }
+
+    /**
+     * Returns true when PHP is configured to load Xdebug automatically.
+     */
+    public function isXdebugLoadedByDefault(): bool
+    {
+        return self::$xdebugLoadedByDefault
+            ?? self::$xdebugLoadedByDefault = stripos(
+                    shell_exec($this->getBinary() . ' -v 2>&1'),
+                    'xdebug'
+                ) !== false;
     }
 
     private function isOpcacheActive(): bool


### PR DESCRIPTION
This is the first stop to solving `php -d zend_extension=xdebug ... phpunit` + process isolation problem.

Unfortunately it's not testable unless shell_exec call is moved elsewhere or made somehow mockable.

----

A different approach would be to run something like `php -r "echo extension_loaded('xdebug');"` which could solve false positives when misconfigured `php -v` might return "could not load library xdebug". 🤔 