### PR TITLE
Add validation to opcache.jit_buffer_size

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -73,7 +73,7 @@ final class Runtime
             return false;
         }
 
-        if (ini_get('opcache.jit_buffer_size' === '0' {
+        if (ini_get('opcache.jit_buffer_size') === '0') {
             return false;
         }
 

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -73,6 +73,10 @@ final class Runtime
             return false;
         }
 
+        if (ini_get('opcache.jit_buffer_size' === 0) {
+            return false;
+        }
+
         if (strpos(ini_get('opcache.jit'), '0') === 0) {
             return false;
         }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -73,7 +73,7 @@ final class Runtime
             return false;
         }
 
-        if (ini_get('opcache.jit_buffer_size' === 0) {
+        if (ini_get('opcache.jit_buffer_size' === '0' {
             return false;
         }
 


### PR DESCRIPTION
A zero value disables the JIT.

https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit-buffer-size

By default this value is "0".
So the JIT is disabled by default, ignoring any value in `opcache.jit`.