### PR TITLE
Fix opcache.jit validation

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -77,7 +77,13 @@ final class Runtime
             return false;
         }
 
-        if (strpos(ini_get('opcache.jit'), '0') === 0) {
+        $jit = ini_get('opcache.jit');
+
+        if (($jit === 'disable') || ($jit === 'off')) {
+            return false;
+        }
+
+        if (strrpos($jit, '0') === 3) {
             return false;
         }
 


### PR DESCRIPTION
https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit

The first '0' only disables the CPU-specific optimization, not the JIT.