### PR TITLE
`Runtime::getRawBinary()`

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -93,14 +93,14 @@ final class Runtime
     /**
      * Returns the path to the binary of the current runtime.
      */
-    public function getBinary(): string
+    public function getRawBinary(): string
     {
         if (self::$initialized) {
             return self::$binary;
         }
 
         if (PHP_BINARY !== '') {
-            self::$binary      = escapeshellarg(PHP_BINARY);
+            self::$binary      = PHP_BINARY;
             self::$initialized = true;
 
             return self::$binary;
@@ -115,7 +115,7 @@ final class Runtime
 
         foreach ($possibleBinaryLocations as $binary) {
             if (is_readable($binary)) {
-                self::$binary      = escapeshellarg($binary);
+                self::$binary      = $binary;
                 self::$initialized = true;
 
                 return self::$binary;
@@ -128,6 +128,14 @@ final class Runtime
         // @codeCoverageIgnoreEnd
 
         return self::$binary;
+    }
+
+    /**
+     * Returns the path to the binary of the current runtime.
+     */
+    public function getBinary(): string
+    {
+        return escapeshellarg($this->getRawBinary());
     }
 
     public function getNameWithVersion(): string

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -91,7 +91,7 @@ final class Runtime
     }
 
     /**
-     * Returns the path to the binary of the current runtime.
+     * Returns the raw path to the binary of the current runtime.
      */
     public function getRawBinary(): string
     {
@@ -131,7 +131,7 @@ final class Runtime
     }
 
     /**
-     * Returns the path to the binary of the current runtime.
+     * Returns the escaped path to the binary of the current runtime.
      */
     public function getBinary(): string
     {

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -41,7 +41,7 @@ final class RuntimeTest extends TestCase
     {
         $this->assertNotEmpty((new Runtime)->getBinary());
     }
-    
+
     public function testRawBinaryCanBeRetrieved(): void
     {
         $this->assertNotEmpty((new Runtime)->getRawBinary());

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -41,6 +41,11 @@ final class RuntimeTest extends TestCase
     {
         $this->assertNotEmpty((new Runtime)->getBinary());
     }
+    
+    public function testRawBinaryCanBeRetrieved(): void
+    {
+        $this->assertNotEmpty((new Runtime)->getRawBinary());
+    }
 
     public function testIsPhpReturnsTrueWhenRunningOnPhp(): void
     {


### PR DESCRIPTION
to pass a command in array-notation to `proc_open` we need it in a raw form. the escaping happens by php-src itself

refs https://github.com/sebastianbergmann/phpunit/issues/5749#issuecomment-2016012543