### PR TITLE
fix second stty call in Console::getNumberOfColumnsInteractive

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -162,7 +162,7 @@ final class Console
                 }
             }
 
-            $stty = shell_exec('stty size');
+            $stty = shell_exec('stty');
 
             if ($stty === false || $stty === null) {
                 $stty = '';


### PR DESCRIPTION
I think with the last update there was a copy-paste error in commit https://github.com/sebastianbergmann/environment/commit/5087c030af0208146c8670c83a70320aabc54815.
Before the 2nd call was always `stty` without parameters, now `stty size` is called twice, which would be redundant?

Only version 8.0.1 seems to be affected.