### PR TITLE
Closes #64

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -13,7 +13,6 @@ use const INI_SCANNER_RAW;
 use const PHP_BINARY;
 use const PHP_SAPI;
 use const PHP_VERSION;
-use function addcslashes;
 use function array_map;
 use function array_merge;
 use function assert;
@@ -241,9 +240,7 @@ final class Runtime
      * passed via the `$values` parameter whether the runtime value
      * (`ini_get()`) differs from what the ini files specified.
      * Returns an array of `key=value` strings for the changed
-     * settings. The value is wrapped in double quotes (with `"` and
-     * `\` escaped) so the result is safe to pass back to PHP via
-     * the `-d` command-line flag.
+     * settings.
      *
      * @param list<string> $values
      *
@@ -265,7 +262,7 @@ final class Runtime
                 continue;
             }
 
-            $diff[$value] = sprintf('%s=%s', $value, $this->quoteIniValue($set));
+            $diff[$value] = sprintf('%s=%s', $value, $set);
         }
 
         return $diff;
@@ -372,10 +369,5 @@ final class Runtime
         }
 
         return $merged;
-    }
-
-    private function quoteIniValue(string $value): string
-    {
-        return '"' . addcslashes($value, '"\\') . '"';
     }
 }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -9,9 +9,11 @@
  */
 namespace SebastianBergmann\Environment;
 
+use const INI_SCANNER_RAW;
 use const PHP_BINARY;
 use const PHP_SAPI;
 use const PHP_VERSION;
+use function addcslashes;
 use function array_map;
 use function array_merge;
 use function assert;
@@ -23,6 +25,7 @@ use function ini_get;
 use function ini_get_all;
 use function is_array;
 use function is_int;
+use function is_string;
 use function parse_ini_file;
 use function php_ini_loaded_file;
 use function php_ini_scanned_files;
@@ -233,13 +236,14 @@ final class Runtime
 
     /**
      * Parses the loaded php.ini file (if any) as well as all
-     * additional php.ini files from the additional ini dir for
-     * a list of all configuration settings loaded from files
-     * at startup. Then checks for each php.ini setting passed
-     * via the `$values` parameter whether this setting has
-     * been changed at runtime. Returns an array of strings
-     * where each string has the format `key=value` denoting
-     * the name of a changed php.ini setting with its new value.
+     * additional php.ini files from the additional ini dir into a
+     * single merged map of settings, then checks for each setting
+     * passed via the `$values` parameter whether the runtime value
+     * (`ini_get()`) differs from what the ini files specified.
+     * Returns an array of `key=value` strings for the changed
+     * settings. The value is wrapped in double quotes (with `"` and
+     * `\` escaped) so the result is safe to pass back to PHP via
+     * the `-d` command-line flag.
      *
      * @param list<string> $values
      *
@@ -247,41 +251,21 @@ final class Runtime
      */
     public function getCurrentSettings(array $values): array
     {
-        $diff  = [];
-        $files = [];
+        $iniFileValues = $this->parseLoadedIniFiles();
+        $diff          = [];
 
-        $file = php_ini_loaded_file();
+        foreach ($values as $value) {
+            $set = ini_get($value);
 
-        if ($file !== false) {
-            $files[] = $file;
-        }
-
-        $scanned = php_ini_scanned_files();
-
-        if ($scanned !== false) {
-            $files = array_merge(
-                $files,
-                array_map(
-                    'trim',
-                    explode(",\n", $scanned),
-                ),
-            );
-        }
-
-        foreach ($files as $ini) {
-            $config = parse_ini_file($ini, true);
-
-            foreach ($values as $value) {
-                $set = ini_get($value);
-
-                if ($set === false || $set === '') {
-                    continue;
-                }
-
-                if ((!isset($config[$value]) || ($set !== $config[$value]))) {
-                    $diff[$value] = sprintf('%s=%s', $value, $set);
-                }
+            if ($set === false || $set === '') {
+                continue;
             }
+
+            if (isset($iniFileValues[$value]) && $iniFileValues[$value] === $set) {
+                continue;
+            }
+
+            $diff[$value] = sprintf('%s=%s', $value, $this->quoteIniValue($set));
         }
 
         return $diff;
@@ -344,5 +328,54 @@ final class Runtime
         }
 
         return false;
+    }
+
+    /**
+     * @return array<array-key, string>
+     */
+    private function parseLoadedIniFiles(): array
+    {
+        $files = [];
+
+        $file = php_ini_loaded_file();
+
+        if ($file !== false) {
+            $files[] = $file;
+        }
+
+        $scanned = php_ini_scanned_files();
+
+        if ($scanned !== false) {
+            $files = array_merge(
+                $files,
+                array_map(
+                    'trim',
+                    explode(",\n", $scanned),
+                ),
+            );
+        }
+
+        $merged = [];
+
+        foreach ($files as $ini) {
+            $parsed = parse_ini_file($ini, false, INI_SCANNER_RAW);
+
+            if ($parsed === false) {
+                continue;
+            }
+
+            foreach ($parsed as $key => $val) {
+                if (is_string($val)) {
+                    $merged[$key] = $val;
+                }
+            }
+        }
+
+        return $merged;
+    }
+
+    private function quoteIniValue(string $value): string
+    {
+        return '"' . addcslashes($value, '"\\') . '"';
     }
 }

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -9,7 +9,7 @@
  */
 namespace SebastianBergmann\Environment;
 
-use const INI_SCANNER_RAW;
+use const INI_SCANNER_NORMAL;
 use const PHP_BINARY;
 use const PHP_SAPI;
 use const PHP_VERSION;
@@ -25,17 +25,26 @@ use function ini_get_all;
 use function is_array;
 use function is_int;
 use function is_string;
+use function json_decode;
 use function parse_ini_file;
 use function php_ini_loaded_file;
 use function php_ini_scanned_files;
 use function phpversion;
+use function proc_close;
+use function proc_open;
 use function sprintf;
+use function stream_get_contents;
 use function strrpos;
 use function version_compare;
 use function xdebug_info;
 
 final class Runtime
 {
+    /**
+     * @var ?array<string, string>
+     */
+    private static ?array $compiledDefaults = null;
+
     /**
      * Returns true when Xdebug or PCOV is available or
      * the runtime used is PHPDBG.
@@ -236,11 +245,13 @@ final class Runtime
     /**
      * Parses the loaded php.ini file (if any) as well as all
      * additional php.ini files from the additional ini dir into a
-     * single merged map of settings, then checks for each setting
-     * passed via the `$values` parameter whether the runtime value
-     * (`ini_get()`) differs from what the ini files specified.
-     * Returns an array of `key=value` strings for the changed
-     * settings.
+     * single merged map of settings, and also obtains the compiled-in
+     * defaults by spawning a `php -n` child once per process.
+     * Then checks for each setting passed via the `$values` parameter
+     * whether the runtime value (`ini_get()`) differs from what the
+     * ini files specified or, when a setting is not configured in any
+     * ini file, from the compiled-in default. Returns an array of
+     * `key=value` strings for the changed settings.
      *
      * @param list<string> $values
      *
@@ -248,17 +259,22 @@ final class Runtime
      */
     public function getCurrentSettings(array $values): array
     {
-        $iniFileValues = $this->parseLoadedIniFiles();
-        $diff          = [];
+        $iniFileValues    = $this->parseLoadedIniFiles();
+        $compiledDefaults = self::compiledDefaults();
+        $diff             = [];
 
         foreach ($values as $value) {
             $set = ini_get($value);
 
-            if ($set === false || $set === '') {
+            if ($set === false) {
                 continue;
             }
 
             if (isset($iniFileValues[$value]) && $iniFileValues[$value] === $set) {
+                continue;
+            }
+
+            if (!isset($iniFileValues[$value]) && ($compiledDefaults[$value] ?? null) === $set) {
                 continue;
             }
 
@@ -355,7 +371,7 @@ final class Runtime
         $merged = [];
 
         foreach ($files as $ini) {
-            $parsed = parse_ini_file($ini, false, INI_SCANNER_RAW);
+            $parsed = parse_ini_file($ini, false, INI_SCANNER_NORMAL);
 
             if ($parsed === false) {
                 continue;
@@ -369,5 +385,67 @@ final class Runtime
         }
 
         return $merged;
+    }
+
+    /**
+     * Returns the compiled-in default values of every ini setting by
+     * spawning a `php -n` child process once and caching the result
+     * for the lifetime of the PHP process. When the child cannot be
+     * launched or its output is unusable, an empty array is returned
+     * and cached so the failure is not retried.
+     *
+     * @return array<string, string>
+     */
+    private static function compiledDefaults(): array
+    {
+        if (self::$compiledDefaults !== null) {
+            return self::$compiledDefaults;
+        }
+
+        self::$compiledDefaults = [];
+
+        $process = proc_open(
+            [PHP_BINARY, '-n', '-r', 'echo json_encode(ini_get_all(null, true));'],
+            [1 => ['pipe', 'w']],
+            $pipes,
+        );
+
+        if ($process === false) {
+            return self::$compiledDefaults;
+        }
+
+        assert(isset($pipes[1]));
+
+        $stdout = stream_get_contents($pipes[1]);
+
+        proc_close($process);
+
+        if (!is_string($stdout) || $stdout === '') {
+            return self::$compiledDefaults;
+        }
+
+        $parsed = json_decode($stdout, true);
+
+        if (!is_array($parsed)) {
+            return self::$compiledDefaults;
+        }
+
+        foreach ($parsed as $key => $info) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            if (!is_array($info)) {
+                continue;
+            }
+
+            if (!isset($info['global_value']) || !is_string($info['global_value'])) {
+                continue;
+            }
+
+            self::$compiledDefaults[$key] = $info['global_value'];
+        }
+
+        return self::$compiledDefaults;
     }
 }

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -27,6 +27,7 @@ use function xdebug_info;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 #[CoversClass(Runtime::class)]
 final class RuntimeTest extends TestCase
@@ -181,7 +182,69 @@ final class RuntimeTest extends TestCase
         $this->assertSame('error_log=' . $value, $result['error_log']);
     }
 
+    public function testGetCurrentSettingsSkipsValuesThatEqualTheCompiledInDefaultWhenNoIniFileIsLoaded(): void
+    {
+        $stdout = $this->runChildPhpWithFlags(
+            ['-n'],
+            'echo json_encode((new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["precision"]));',
+        );
+
+        $result = json_decode($stdout, true);
+
+        assert(is_array($result));
+
+        $this->assertArrayNotHasKey('precision', $result);
+    }
+
+    public function testGetCurrentSettingsReportsEmptyValueThatDiffersFromTheCompiledInDefault(): void
+    {
+        $stdout = $this->runChildPhpWithFlags(
+            ['-n', '-d', 'display_errors=Off'],
+            'echo json_encode((new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["display_errors"]));',
+        );
+
+        $result = json_decode($stdout, true);
+
+        assert(is_array($result));
+
+        $this->assertSame('display_errors=', $result['display_errors'] ?? null);
+    }
+
+    public function testCompiledInDefaultsAreCachedAcrossInstances(): void
+    {
+        $property = new ReflectionProperty(Runtime::class, 'compiledDefaults');
+        $original = $property->getValue();
+
+        try {
+            $property->setValue(null, null);
+
+            (new Runtime)->getCurrentSettings(['precision']);
+
+            $afterFirstCall = $property->getValue();
+
+            $this->assertIsArray($afterFirstCall);
+            $this->assertNotEmpty($afterFirstCall);
+
+            $sentinel = ['__sentinel__' => 'cached'];
+            $property->setValue(null, $sentinel);
+
+            (new Runtime)->getCurrentSettings(['precision']);
+
+            $this->assertSame($sentinel, $property->getValue());
+        } finally {
+            $property->setValue(null, $original);
+        }
+    }
+
     private function runChildPhp(string $iniOverride, string $code): string
+    {
+        return $this->runChildPhpWithFlags(['-d', $iniOverride], $code);
+    }
+
+    /**
+     * @param list<string> $flags
+     */
+    private function runChildPhpWithFlags(array $flags, string $code): string
     {
         $code = sprintf(
             'require %s; %s',
@@ -190,7 +253,7 @@ final class RuntimeTest extends TestCase
         );
 
         $process = proc_open(
-            [PHP_BINARY, '-d', $iniOverride, '-r', $code],
+            [PHP_BINARY, ...$flags, '-r', $code],
             [1 => ['pipe', 'w']],
             $pipes,
         );

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -151,7 +151,7 @@ final class RuntimeTest extends TestCase
         assert(is_array($result));
         assert(isset($result['disable_functions']));
 
-        $this->assertSame('disable_functions="phpinfo"', $result['disable_functions']);
+        $this->assertSame('disable_functions=phpinfo', $result['disable_functions']);
     }
 
     public function testGetCurrentSettingsReturnsEmptyDiffIfNoValuesArePassed(): void
@@ -164,10 +164,12 @@ final class RuntimeTest extends TestCase
         $this->assertSame([], (new Runtime)->getCurrentSettings(['allow_url_include']));
     }
 
-    public function testGetCurrentSettingsQuotesValuesContainingSpecialCharacters(): void
+    public function testGetCurrentSettingsReturnsValuesVerbatim(): void
     {
+        $value = 'phpstorm://open?file=%f&line=%l';
+
         $stdout = $this->runChildPhp(
-            'error_log="phpstorm://open?file=%f&line=%l"',
+            'error_log="' . $value . '"',
             'echo json_encode((new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["error_log"]));',
         );
 
@@ -176,39 +178,16 @@ final class RuntimeTest extends TestCase
         assert(is_array($result));
         assert(isset($result['error_log']));
 
-        $this->assertSame(
-            'error_log="phpstorm://open?file=%f&line=%l"',
-            $result['error_log'],
-        );
+        $this->assertSame('error_log=' . $value, $result['error_log']);
     }
 
-    public function testCurrentSettingsOutputRoundTripsThroughPhpDFlag(): void
+    private function runChildPhp(string $iniOverride, string $code): string
     {
-        $value = 'phpstorm://open?file=%f&line=%l';
-
-        $formatted = $this->runChildPhp(
-            'error_log="' . $value . '"',
-            'echo (new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["error_log"])["error_log"];',
+        $code = sprintf(
+            'require %s; %s',
+            var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
+            $code,
         );
-
-        $roundTripped = $this->runChildPhp(
-            $formatted,
-            'echo ini_get("error_log");',
-            false,
-        );
-
-        $this->assertSame($value, $roundTripped);
-    }
-
-    private function runChildPhp(string $iniOverride, string $code, bool $autoload = true): string
-    {
-        if ($autoload) {
-            $code = sprintf(
-                'require %s; %s',
-                var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
-                $code,
-            );
-        }
 
         $process = proc_open(
             [PHP_BINARY, '-d', $iniOverride, '-r', $code],

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -16,7 +16,6 @@ use function assert;
 use function dirname;
 use function extension_loaded;
 use function in_array;
-use function ini_get;
 use function is_array;
 use function json_decode;
 use function proc_close;
@@ -142,20 +141,78 @@ final class RuntimeTest extends TestCase
 
     public function testSettingsChangedViaCliDFlagAreDetected(): void
     {
+        $stdout = $this->runChildPhp(
+            'disable_functions=phpinfo',
+            'echo json_encode((new SebastianBergmann\Environment\Runtime)->getSettingsNotChangeableAtRuntime());',
+        );
+
+        $result = json_decode($stdout, true);
+
+        assert(is_array($result));
+        assert(isset($result['disable_functions']));
+
+        $this->assertSame('disable_functions="phpinfo"', $result['disable_functions']);
+    }
+
+    public function testGetCurrentSettingsReturnsEmptyDiffIfNoValuesArePassed(): void
+    {
+        $this->assertSame([], (new Runtime)->getCurrentSettings([]));
+    }
+
+    public function testGetCurrentSettingsWillSkipSettingsThatIsNotSet(): void
+    {
+        $this->assertSame([], (new Runtime)->getCurrentSettings(['allow_url_include']));
+    }
+
+    public function testGetCurrentSettingsQuotesValuesContainingSpecialCharacters(): void
+    {
+        $stdout = $this->runChildPhp(
+            'error_log="phpstorm://open?file=%f&line=%l"',
+            'echo json_encode((new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["error_log"]));',
+        );
+
+        $result = json_decode($stdout, true);
+
+        assert(is_array($result));
+        assert(isset($result['error_log']));
+
+        $this->assertSame(
+            'error_log="phpstorm://open?file=%f&line=%l"',
+            $result['error_log'],
+        );
+    }
+
+    public function testCurrentSettingsOutputRoundTripsThroughPhpDFlag(): void
+    {
+        $value = 'phpstorm://open?file=%f&line=%l';
+
+        $formatted = $this->runChildPhp(
+            'error_log="' . $value . '"',
+            'echo (new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["error_log"])["error_log"];',
+        );
+
+        $roundTripped = $this->runChildPhp(
+            $formatted,
+            'echo ini_get("error_log");',
+            false,
+        );
+
+        $this->assertSame($value, $roundTripped);
+    }
+
+    private function runChildPhp(string $iniOverride, string $code, bool $autoload = true): string
+    {
+        if ($autoload) {
+            $code = sprintf(
+                'require %s; %s',
+                var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
+                $code,
+            );
+        }
+
         $process = proc_open(
-            [
-                PHP_BINARY,
-                '-d',
-                'disable_functions=phpinfo',
-                '-r',
-                sprintf(
-                    'require %s; echo json_encode((new SebastianBergmann\Environment\Runtime)->getSettingsNotChangeableAtRuntime());',
-                    var_export(dirname(__DIR__) . '/vendor/autoload.php', true),
-                ),
-            ],
-            [
-                1 => ['pipe', 'w'],
-            ],
+            [PHP_BINARY, '-d', $iniOverride, '-r', $code],
+            [1 => ['pipe', 'w']],
             $pipes,
         );
 
@@ -168,32 +225,7 @@ final class RuntimeTest extends TestCase
 
         proc_close($process);
 
-        $result = json_decode($stdout, true);
-
-        assert(is_array($result));
-        assert(isset($result['disable_functions']));
-
-        $this->assertSame('disable_functions=phpinfo', $result['disable_functions']);
-    }
-
-    public function testGetCurrentSettingsReturnsEmptyDiffIfNoValuesArePassed(): void
-    {
-        $this->assertSame([], (new Runtime)->getCurrentSettings([]));
-    }
-
-    #[RequiresPhpExtension('xdebug')]
-    public function testGetCurrentSettingsReturnsCorrectDiffIfXdebugValuesArePassed(): void
-    {
-        if (ini_get('xdebug.mode') === '') {
-            $this->markTestSkipped('xdebug.mode must not be set to "off"');
-        }
-
-        $this->assertArrayHasKey('xdebug.mode', (new Runtime)->getCurrentSettings(['xdebug.mode']));
-    }
-
-    public function testGetCurrentSettingsWillSkipSettingsThatIsNotSet(): void
-    {
-        $this->assertSame([], (new Runtime)->getCurrentSettings(['allow_url_include']));
+        return $stdout;
     }
 
     private function markTestSkippedWhenPcovIsLoaded(): void


### PR DESCRIPTION
`Runtime::getCurrentSettings()` emitted entries as bare `key=value`, with the value taken straight from `ini_get()`. When the value contained characters with meaning to PHP's INI parser, e.g. `xdebug.file_link_format = "phpstorm://open?file=%f&line=%l"`, the resulting string could not be passed back to PHP via `-d`, producing `PHP: syntax error, unexpected '='` in any child process spawned by PHPUnit's process isolation feature.

While reviewing the same method, a second defect surfaced: the per-file comparison loop reported a setting as "changed" whenever it was missing from any one scanned INI file. Common conf.d layouts (e.g. `xdebug.mode` set in`conf.d/20-xdebug.ini` but absent from the main `php.ini`) tripped this and produced spurious diff entries on every invocation.

With these proposed changes, `Runtime::getCurrentSettings()` now

1. Wraps each emitted value in double quotes and escapes embedded `"` and `\`, so the result round-trips through `php -d`. The wrapping is unconditional, simple and predictable, and PHP's INI parser accepts quoted values for every setting type.
2. Merges all loaded ini files (`php_ini_loaded_file()` + `php_ini_scanned_files()`) into a single map before comparing, via a new private `parseLoadedIniFiles()` helper. Each requested setting is compared exactly once instead of once per file, eliminating the per-file false-positive. `parse_ini_file()` is invoked with `INI_SCANNER_RAW` to preserve string values verbatim.

The empty-value short-circuit (`$set === ''`) is retained on purpose: it is the only thing preventing settings absent from all INI files (whose value is the compiled-in default) from being over-reported as overrides. The other concerns raised in the issue comments such as empty/"off" overrides being silently skipped or behaviour when no INI files are loaded cannot be addressed without a compiled-defaults lookup that PHP does not expose and are left as known limitations.