### PR TITLE
Fix `Runtime::getCurrentSettings()` forwarding spurious empty overrides for php.ini-only extensions

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -13,6 +13,7 @@ use const INI_SCANNER_NORMAL;
 use const PHP_BINARY;
 use const PHP_SAPI;
 use const PHP_VERSION;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function assert;
@@ -253,6 +254,15 @@ final class Runtime
      * ini file, from the compiled-in default. Returns an array of
      * `key=value` strings for the changed settings.
      *
+     * A setting whose runtime value is the empty string but that is
+     * absent from both the ini files and the compiled-in defaults is
+     * left alone: there is no evidence that it was overridden, so it
+     * is not forwarded. This avoids spurious empty overrides for
+     * settings of extensions that are not visible to the compiled-in
+     * defaults probe (e.g. extensions loaded only via php.ini), which
+     * would otherwise break child processes (see
+     * https://github.com/sebastianbergmann/environment/issues/99).
+     *
      * @param list<string> $values
      *
      * @return array<string, string>
@@ -275,6 +285,12 @@ final class Runtime
             }
 
             if (!isset($iniFileValues[$value]) && ($compiledDefaults[$value] ?? null) === $set) {
+                continue;
+            }
+
+            if ($set === '' &&
+                !isset($iniFileValues[$value]) &&
+                !array_key_exists($value, $compiledDefaults)) {
                 continue;
             }
 

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -26,6 +26,7 @@ use function var_export;
 use function xdebug_info;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\Ticket;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -208,6 +209,27 @@ final class RuntimeTest extends TestCase
         assert(is_array($result));
 
         $this->assertSame('display_errors=', $result['display_errors'] ?? null);
+    }
+
+    #[Ticket('https://github.com/sebastianbergmann/environment/issues/99')]
+    public function testGetCurrentSettingsLeavesAloneEmptyValueAbsentFromIniFilesAndCompiledInDefaults(): void
+    {
+        // A setting whose runtime value is the empty string but that is absent from both the
+        // loaded ini files and the compiled-in defaults (e.g. an ini setting of an extension
+        // loaded only via php.ini, which the `php -n` probe does not load) must not be
+        // forwarded as an empty `-d key=` override to child processes.
+        $stdout = $this->runChildPhpWithFlags(
+            ['-n', '-d', 'error_log='],
+            '$property = new ReflectionProperty(SebastianBergmann\Environment\Runtime::class, "compiledDefaults");' .
+            '$property->setValue(null, ["precision" => "14"]);' .
+            'echo json_encode((new SebastianBergmann\Environment\Runtime)->getCurrentSettings(["error_log"]));',
+        );
+
+        $result = json_decode($stdout, true);
+
+        assert(is_array($result));
+
+        $this->assertArrayNotHasKey('error_log', $result);
     }
 
     public function testCompiledInDefaultsAreCachedAcrossInstances(): void


### PR DESCRIPTION
`getCurrentSettings()` now skips a setting when all of the following hold:

- its runtime value is the empty string, and
- it is absent from the loaded ini files, and
- it is absent from the compiled-in defaults.

```php
if ($set === '' &&
    !isset($iniFileValues[$value]) &&
    !array_key_exists($value, $compiledDefaults)) {
    continue;
}
```

The existing compiled-default check used `($compiledDefaults[$value] ?? null) === $set`, which cannot tell "absent" apart from "present and empty"; the new guard uses `array_key_exists()` precisely for that distinction.

This is deliberately narrower than the old blanket `$set === ''` skip, so the empty/"off" override detection that 616034c added is preserved: an empty or `Off` value is still reported whenever there is evidence for it (the setting appears in an ini file, or in the compiled-in defaults).

The guard only bows out when there is no evidence at all that an override happened, which is exactly the `apc.preload_path` case, and more generally any ini setting of an extension that is invisible to the `php -n` probe.

This is complementary to #98, not a replacement for it. #98 reads `builtin_default_value` from `ini_get_all()` in-process, but that relies on https://github.com/php/php-src/pull/22134, which is still open against `master`. Until that ships and users upgrade to a PHP version that has it, #98 falls back to the same `php -n` child-process probe.